### PR TITLE
Fixed example in documentation

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -389,7 +389,7 @@ export default function ApiRefTable({
       validate: ${
         isStandard
           ? `value => value === '1'`
-          : `value => value === '1' || 'error message';  // <p>error message</p>`
+          : `value => value === '1' || 'error message'  // <p>error message</p>`
       }
     })
   }
@@ -421,7 +421,7 @@ export default function ApiRefTable({
       validate: ${
         isStandard
           ? `async value => await fetch(url)`
-          : `async value => await fetch(url) || 'error message';  // <p>error message</p>`
+          : `async value => await fetch(url) || 'error message'  // <p>error message</p>`
       }
     })
   }


### PR DESCRIPTION
It was rendering a semicolon inside an object.

Fixed version 👇 
```
    register({
      validate: value => value === '1'
    })
```