### PR TITLE
Improve Contributor Experience 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at bluebill1049@hotmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to `React Hook Form` (The Docs)
+
+As the creators and maintainers of this project, we want to ensure that `react-hook-form` lives and continues to grow and evolve. We would like to encourage everyone to help and support this library by contributing.
+
+## Code contributions
+
+Here is a quick guide to doing code contributions to the library.
+
+1. Fork and clone the repo to your local machine `git clone https://github.com/YOUR_GITHUB_USERNAME/website.git`
+
+2. Create a new branch from `master` with a meaningful name for a new feature or an issue you want to work on: `git checkout -b your-meaningful-branch-name`
+
+3. Install packages by running:
+
+   > yarn
+
+4. Startup a local version of the docs
+
+   > yarn start
+
+5. Ensure your code is formatted properly
+
+   > yarn format
+
+6. Push your branch: `git push -u origin your-meaningful-branch-name`
+
+7. Submit a pull request to the upstream react-hook-form repository.
+
+8. Choose a descriptive title and describe your changes briefly.
+
+## Coding style
+
+Please follow the coding style of the project. React Hook Form uses prettier. If possible, enable the prettier plugin in your editor to get real-time feedback. The formatting can be run manually with the following command: `yarn format`
+
+## License
+
+By contributing your code to the react-hook-form GitHub repository, you agree to license your contribution under the MIT license.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Thanks goes to these wonderful people. [[Become a contributor](https://github.co
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />
 </a>
     
-#### Thanks to 
+#### Thanks to
 
-* WebStorm for IDE license
-* ZEIT for free hosting 
-* React ❤️
+- WebStorm for IDE license
+- Vercel for free hosting
+- React ❤️

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -121,7 +121,15 @@ export default ({ currentLanguage }: { currentLanguage: string }) => {
         >
           @github
         </a>
-        ️ ]
+        ️ ] [ Help make these doc's better{" "}
+        <a
+          href="https://github.com/react-hook-form/website"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          @github
+        </a>{" "}
+        ]
       </p>
       <p
         style={{
@@ -132,7 +140,7 @@ export default ({ currentLanguage }: { currentLanguage: string }) => {
           borderRadius: 4,
         }}
       >
-        Hosted on ▲ ZEIT Now
+        Hosted on ▲ Vercel Now
       </p>
     </footer>
   )

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -30,7 +30,7 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
       <div className={styles.iconGroup}>
         <span className={styles.icon}>
           <a
-            href="https://github.com/bluebill1049/react-hook-form"
+            href="https://github.com/react-hook-form"
             target="_blank"
             rel="noopener noreferrer"
             title="React Hook Form Github"


### PR DESCRIPTION
Modified footer to add link to docs github:
<img width="753" alt="react-hook-form-docs-link" src="https://user-images.githubusercontent.com/35811186/83975419-e5749a00-a8c1-11ea-88c9-2a509d2abd76.png">

Changed the github header Link to take you to the [react-hook-form general github](https://github.com/react-hook-form) repo. This change makes it easier to see everything react-hook-form has to offer.

Added CODE_OF_CONDUCT.md and CONTRIBUTING.md with small changes from main [react-hook-form page](https://github.com/react-hook-form/react-hook-form). 

ZEIT changed its name to [Vercel](https://vercel.com/). #what-21-million-in-funding-does

**This PR Merges into master, not V6 like my other PR's**