### PR TITLE
Feature/get-started-example-update

### DIFF
--- a/src/components/Bday.tsx
+++ b/src/components/Bday.tsx
@@ -37,7 +37,7 @@ export default ({ isCardPlay }: { isCardPlay: boolean }) => {
               opacity: "0",
             }}
             delay={0.1}
-            easeType={"ease-in"}
+            easeType="ease-in"
             render={({ style }) => {
               return (
                 <>
@@ -61,7 +61,7 @@ export default ({ isCardPlay }: { isCardPlay: boolean }) => {
               transform: "translate(130px, 80px) scale(1.3)",
             }}
             delay={0.2}
-            easeType={"ease-in"}
+            easeType="ease-in"
             render={({ style }) => (
               <div className={styles.cake} style={style}>
                 <svg viewBox="0 0 100 80">
@@ -103,7 +103,7 @@ export default ({ isCardPlay }: { isCardPlay: boolean }) => {
               opacity: "0",
             }}
             delay={0.1}
-            easeType={"ease-in"}
+            easeType="ease-in"
             render={({ style }) => {
               return (
                 <div className={styles.achievement} style={style}>
@@ -119,7 +119,7 @@ export default ({ isCardPlay }: { isCardPlay: boolean }) => {
                             transform: "translateX(10px)",
                             opacity: 0,
                           }}
-                          easeType={"ease-in"}
+                          easeType="ease-in"
                           duration={0.15}
                           delay={index === 0 ? 0.2 : 0.01}
                           render={({ style }) => <li style={style}>{item}</li>}

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -45,26 +45,6 @@ export default function GetStarted({
         </button>
       </span>
 
-      <span
-        className={`${styles.installCode} ${
-          lightMode ? styles.lightInstallCode : ""
-        }`}
-      >
-        yarn add react-hook-form
-        <button
-          className={styles.copyButton}
-          onClick={() => {
-            copyClipBoard("yarn add react-hook-form")
-            alert(generic.copied[currentLanguage])
-          }}
-        >
-          <span className={codeAreaStyles.copyIcon}>
-            <span />
-          </span>{" "}
-          {generic.copy[currentLanguage]}
-        </button>
-      </span>
-
       <h2
         style={{
           marginTop: 50,

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -56,7 +56,7 @@ export default function GetStarted({
       <CodeArea
         rawData={code}
         tsRawData={codeTs}
-        url="https://codesandbox.io/s/kw7z2q2n15"
+        url="https://codesandbox.io/s/react-hook-form-get-started-8bugv"
         tsUrl="https://codesandbox.io/s/react-hook-form-get-started-ts-resrg"
       />
     </>

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -56,7 +56,7 @@ export default function GetStarted({
       <CodeArea
         rawData={code}
         tsRawData={codeTs}
-        url="https://codesandbox.io/s/react-hook-form-get-started-8bugv"
+        url="https://codesandbox.io/s/react-hook-form-get-started-75ijs"
         tsUrl="https://codesandbox.io/s/react-hook-form-get-started-ts-resrg"
       />
     </>

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -45,6 +45,26 @@ export default function GetStarted({
         </button>
       </span>
 
+      <span
+        className={`${styles.installCode} ${
+          lightMode ? styles.lightInstallCode : ""
+        }`}
+      >
+        yarn add react-hook-form
+        <button
+          className={styles.copyButton}
+          onClick={() => {
+            copyClipBoard("yarn add react-hook-form")
+            alert(generic.copied[currentLanguage])
+          }}
+        >
+          <span className={codeAreaStyles.copyIcon}>
+            <span />
+          </span>{" "}
+          {generic.copy[currentLanguage]}
+        </button>
+      </span>
+
       <h2
         style={{
           marginTop: 50,

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -76,7 +76,7 @@ export default function GetStarted({
       <CodeArea
         rawData={code}
         tsRawData={codeTs}
-        url="https://codesandbox.io/s/react-hook-form-get-started-75ijs"
+        url="https://codesandbox.io/s/kw7z2q2n15"
         tsUrl="https://codesandbox.io/s/react-hook-form-get-started-ts-resrg"
       />
     </>

--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -8,6 +8,7 @@ import {
   migrateCode,
   migrateCodeTs,
   uiLibrary,
+  uiLibraryTs,
   globalState,
   errors,
   applyValidation,
@@ -233,7 +234,9 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
 
           <CodeArea
             rawData={uiLibrary}
-            url="https://codesandbox.io/s/72j69vnk1x"
+            url="https://codesandbox.io/s/react-hook-form-custom-input-w4zwg"
+            tsRawData={uiLibraryTs}
+            tsUrl="https://codesandbox.io/s/react-hook-form-custom-input-ts-nzi1f"
           />
 
           <h2

--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -6,6 +6,7 @@ import {
   registerCode,
   registerCodeTs,
   migrateCode,
+  migrateCodeTs,
   uiLibrary,
   globalState,
   errors,
@@ -214,7 +215,9 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
 
           <CodeArea
             rawData={migrateCode}
-            url="https://codesandbox.io/s/adapting-existing-form-3mspt"
+            url="https://codesandbox.io/s/react-hook-form-adapting-existing-form-j1n32"
+            tsRawData={migrateCodeTs}
+            tsUrl="https://codesandbox.io/s/react-hook-form-adapting-existing-form-ts-f3kt1"
           />
 
           <h2

--- a/src/components/IsolateRender.tsx
+++ b/src/components/IsolateRender.tsx
@@ -137,7 +137,7 @@ function IsolateRender({
           end={{
             opacity: 1,
           }}
-          easeType={"ease-in"}
+          easeType="ease-in"
           render={({ style }) => {
             return (
               <section style={style} id="isolate">
@@ -168,7 +168,7 @@ function IsolateRender({
             opacity: 1,
           }}
           delay={0.25}
-          easeType={"ease-in"}
+          easeType="ease-in"
         >
           <p>VS</p>
           <div className={styles.line} />
@@ -182,7 +182,7 @@ function IsolateRender({
           end={{
             opacity: 1,
           }}
-          easeType={"ease-in"}
+          easeType="ease-in"
           render={({ style }) => {
             return <ControlledInputs style={style} />
           }}

--- a/src/components/ResourcePage.tsx
+++ b/src/components/ResourcePage.tsx
@@ -53,7 +53,7 @@ export default function ResourcePage({ defaultLang }: { defaultLang: string }) {
               <Animate
                 key={url}
                 play
-                easeType={"ease-in"}
+                easeType="ease-in"
                 delay={delay}
                 start={{ transform: "translate(20px, 20px)", opacity: 0 }}
                 render={({ style }) => (

--- a/src/components/Watcher.tsx
+++ b/src/components/Watcher.tsx
@@ -120,7 +120,7 @@ export default ({
 
   return (
     <AnimateGroup play={isPlayWatch}>
-      <div className={styles.watcher} id={"watch"}>
+      <div className={styles.watcher} id="watch">
         <div className={containerStyles.centerContent}>
           <h1 className={typographyStyles.h1}>Subscribe Input Change</h1>
           <p>

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -38,7 +38,7 @@ export default function App() {
   const { register, handleSubmit } = useForm<IFormInput>();
 
   const onSubmit = (data: IFormInput) => {
-    console.log(data);
+    alert(JSON.stringify(data));
   };
 
   return (

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -38,7 +38,7 @@ export default function App() {
   const { register, handleSubmit } = useForm<IFormInput>();
 
   const onSubmit = (data: IFormInput) => {
-    alert(JSON.stringify(data));
+    console.log(data)
   };
 
   return (
@@ -156,7 +156,7 @@ const App = () => {
   const { register, handleSubmit } = useForm<IFormValues>();
 
   const onSubmit = (data: IFormValues) => {
-    alert(JSON.stringify(data));
+    console.log(data)
   };
 
   return (
@@ -236,7 +236,7 @@ const App = () => {
   const { control, handleSubmit } = useForm();
 
   const onSubmit = data => {
-    alert(JSON.stringify(data));
+    console.log(data)
   };
 
   return (
@@ -286,7 +286,7 @@ const App = () => {
   const { control, handleSubmit } = useForm<IFormInput>();
 
   const onSubmit = (data: IFormInput) => {
-    alert(JSON.stringify(data));
+    console.log(data)
   };
 
   return (

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -94,6 +94,81 @@ export default function App() {
   );
 }`
 
+export const migrateCodeTs = `import React from "react";
+import { useForm } from "react-hook-form";
+
+type RefReturn =
+  | string
+  | ((instance: HTMLInputElement | null) => void)
+  | React.RefObject<HTMLInputElement>
+  | null
+  | undefined;
+
+type InputProps = React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> & {
+  label: string;
+  register: ({ required }: { required?: boolean }) => RefReturn;
+};
+
+interface IInputProps {
+  label: string;
+}
+
+// The following component is an example of your existing Input Component
+const Input: React.FC<InputProps> = ({ label, register, required }) => (
+  <>
+    <label>{label}</label>
+    <input name={label} ref={register({ required })} />
+  </>
+);
+
+type Option = {
+  label: React.ReactNode;
+  value: string | number | string[];
+};
+
+type SelectProps = React.DetailedHTMLProps<
+  React.SelectHTMLAttributes<HTMLSelectElement>,
+  HTMLSelectElement
+> & { options: Option[] } & HTMLSelectElement;
+
+// you can use React.forwardRef to pass the ref too
+const Select = React.forwardRef<SelectProps, { label: string }>(
+  ({ label }, ref) => (
+    <>
+      <label>{label}</label>
+      <select name={label} ref={ref}>
+        <option value="20">20</option>
+        <option value="30">30</option>
+      </select>
+    </>
+  )
+);
+
+interface IFormValues {
+  "First Name": string;
+  Age: number;
+}
+
+const App = () => {
+  const { register, handleSubmit } = useForm<IFormValues>();
+
+  const onSubmit = (data: IFormValues) => {
+    alert(JSON.stringify(data));
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Input label="First Name" register={register} required />
+      <Select label="Age" ref={register} />
+      <input type="submit" />
+    </form>
+  );
+};
+`
+
 export const uiLibrary = `import React from "react";
 import { useForm } from "react-hook-form";
 import Select from "react-select";

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -197,36 +197,97 @@ export default function App() {
 `
 
 export const uiLibraryHookInput = `import React from "react";
-import { useForm, Controller } from "react-hook-form";
 import Select from "react-select";
-import Input from "@material-ui/core/Input";
-import { Input as InputField } from "antd";
+import { useForm, Controller } from "react-hook-form";
+import MaterialUIInput from "@material-ui/core/Input";
+import { Input as AntdInput } from "antd";
 
-export default function App() {
+const App = () => {
   const { control, handleSubmit } = useForm();
-  const onSubmit = data => console.log(data);
+
+  const onSubmit = data => {
+    alert(JSON.stringify(data));
+  };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Controller as={Input} name="HelloWorld" control={control} defaultValue="" />
-      <Controller as={InputField} name="AntdInput" control={control} defaultValue="" />
       <Controller
-        name="reactSelect"
+        as={MaterialUIInput}
+        name="firstName"
+        control={control}
+        defaultValue=""
+      />
+      <Controller
+        as={AntdInput}
+        name="lastName"
+        control={control}
+        defaultValue=""
+      />
+      <Controller
+        name="iceCreamType"
+        as={Select}
         options={[
           { value: "chocolate", label: "Chocolate" },
           { value: "strawberry", label: "Strawberry" },
           { value: "vanilla", label: "Vanilla" }
         ]}
         control={control}
-        defaultValue={{}}
         rules={{ required: true }}
       />
-
       <input type="submit" />
     </form>
   );
-}
+};
 `
+
+export const uiLibraryHookInputTs = `import React from "react";
+import Select from "react-select";
+import { useForm, Controller } from "react-hook-form";
+import MaterialUIInput from "@material-ui/core/Input";
+import { Input as AntdInput } from "antd";
+
+interface IFormInput {
+  firstName: string;
+  lastName: string;
+  iceCreamType: string;
+}
+
+const App = () => {
+  const { control, handleSubmit } = useForm<IFormInput>();
+
+  const onSubmit = (data: IFormInput) => {
+    alert(JSON.stringify(data));
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        as={MaterialUIInput}
+        name="firstName"
+        control={control}
+        defaultValue=""
+        className="materialUIInput"
+      />
+      <Controller
+        as={AntdInput}
+        name="lastName"
+        control={control}
+        defaultValue=""
+      />
+      <Controller
+        name="iceCreamType"
+        as={Select}
+        options={[
+          { value: "chocolate", label: "Chocolate" },
+          { value: "strawberry", label: "Strawberry" },
+          { value: "vanilla", label: "Vanilla" }
+        ]}
+        control={control}
+      />
+      <input type="submit" />
+    </form>
+  );
+};`
 
 export const controlledComponent = `import React from "react";
 import { useForm, Controller } from "react-hook-form";

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -189,12 +189,42 @@ export default function App() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <InputField onChange={handleChange} />
+      <InputField name="name" onChange={handleChange} />
       <input type="submit" />
     </form>
   );
 }
 `
+
+export const uiLibraryTs = `import React from "react";
+import { useForm } from "react-hook-form";
+import Select from "react-select";
+import Input from "@material-ui/core/Input";
+import { Input as InputField } from "antd";
+
+interface IFormInput {
+  name: string
+}
+
+export default function App() {
+  const { register, handleSubmit, setValue } = useForm();
+  const onSubmit = data => console.log(data);
+  
+  const handleChange = (e) => {
+    setValue("AntdInput", e.target.value);
+  }
+  
+  React.useEffect(() => {
+    register("AntdInput"); // custom register Antd input
+  }, [register])
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <InputField name="name" onChange={handleChange} />
+      <input type="submit" />
+    </form>
+  );
+}`
 
 export const uiLibraryHookInput = `import React from "react";
 import Select from "react-select";

--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -300,7 +300,7 @@ export default {
           >
             link for such implementation.
           </a>{" "}
-          with <PageLink to={"/api#Controller"}>Controller</PageLink>.
+          with <PageLink to="/api#Controller">Controller</PageLink>.
         </p>
       </>
     ),

--- a/src/data/en/getStarted.tsx
+++ b/src/data/en/getStarted.tsx
@@ -3,7 +3,10 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "@reach/router"
 import translateLink from "../../components/logic/translateLink"
 import CodeArea from "../../components/CodeArea"
-import { uiLibraryHookInput } from "../../components/codeExamples/getStarted"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
 import typographyStyles from "../../styles/typography.module.css"
 
 export default {
@@ -185,7 +188,12 @@ export default {
           <Link to="/api#Controller">Controller</Link> wrapper component, which
           will take care of the registration process for you.
         </p>
-        <CodeArea rawData={uiLibraryHookInput} />
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
         <p>
           <b className={typographyStyles.note}>Option 3:</b> Lastly we can set
           up a custom register using the{" "}

--- a/src/data/es/advanced.tsx
+++ b/src/data/es/advanced.tsx
@@ -302,7 +302,7 @@ export default {
           >
             link para esa implementación.
           </a>{" "}
-          con <PageLink to={"/api#Controller"}>Controller</PageLink>.
+          con <PageLink to="/api#Controller">Controller</PageLink>.
         </p>
       </>
     ),

--- a/src/data/es/getStarted.tsx
+++ b/src/data/es/getStarted.tsx
@@ -3,7 +3,10 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "@reach/router"
 import translateLink from "../../components/logic/translateLink"
 import CodeArea from "../../components/CodeArea"
-import { uiLibraryHookInput } from "../../components/codeExamples/getStarted"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
 import typographyStyles from "../../styles/typography.module.css"
 
 export default {
@@ -178,7 +181,12 @@ export default {
           <Link to="/api#Controller">Controller</Link>, cuando utilizas este
           componente, él se encarga de realizar el proceso de registro por ti.
         </p>
-        <CodeArea rawData={uiLibraryHookInput} />
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
         <p>
           <b className={typographyStyles.note}>Opción 3:</b> Por último, puedes
           configurar un registro personalizado utilizando el hook{" "}

--- a/src/data/jp/advanced.tsx
+++ b/src/data/jp/advanced.tsx
@@ -298,7 +298,7 @@ export default {
         <p>
           <b className={typographyStyles.note}>注意：</b>{" "}
           アプリケーションにフィールドの削除や挿入、追加、先頭に追加などの機能が必要な場合は、{" "}
-          <PageLink to={"/api#Controller"}>Controller</PageLink> を使用した
+          <PageLink to="/api#Controller">Controller</PageLink> を使用した
           <a
             href="https://codesandbox.io/s/react-hook-form-field-array-advanced-with-delete-insert-append-edit-gvgg4"
             target="_blank"

--- a/src/data/jp/getStarted.tsx
+++ b/src/data/jp/getStarted.tsx
@@ -3,7 +3,10 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "gatsby"
 import translateLink from "../../components/logic/translateLink"
 import CodeArea from "../../components/CodeArea"
-import { uiLibraryHookInput } from "../../components/codeExamples/getStarted"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
 import typographyStyles from "../../styles/typography.module.css"
 
 export default {
@@ -187,7 +190,12 @@ export default {
           このコンポーネントはカスタム登録処理を行います。
         </p>
 
-        <CodeArea rawData={uiLibraryHookInput} />
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
         <p>
           <b className={typographyStyles.note}>オプション3：</b> 最後に{" "}
           <a

--- a/src/data/kr/advanced.tsx
+++ b/src/data/kr/advanced.tsx
@@ -295,7 +295,7 @@ export default {
           >
             link for such implementation.
           </a>{" "}
-          with <PageLink to={"/api#Controller"}>Controller</PageLink>.
+          with <PageLink to="/api#Controller">Controller</PageLink>.
         </p>
       </>
     ),

--- a/src/data/kr/getStarted.tsx
+++ b/src/data/kr/getStarted.tsx
@@ -3,7 +3,10 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "gatsby"
 import translateLink from "../../components/logic/translateLink"
 import CodeArea from "../../components/CodeArea"
-import { uiLibraryHookInput } from "../../components/codeExamples/getStarted"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
 import typographyStyles from "../../styles/typography.module.css"
 
 export default {
@@ -181,7 +184,12 @@ export default {
           과정을 대신 처리해 줍니다.
         </p>
 
-        <CodeArea rawData={uiLibraryHookInput} />
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
         <p>
           <b className={typographyStyles.note}>옵션 3:</b>마지막으로 the{" "}
           <a

--- a/src/data/pt/advanced.tsx
+++ b/src/data/pt/advanced.tsx
@@ -302,7 +302,7 @@ export default {
           >
             link para esta implementação.
           </a>{" "}
-          com <PageLink to={"/api#Controller"}>Controller</PageLink>.
+          com <PageLink to="/api#Controller">Controller</PageLink>.
         </p>
       </>
     ),

--- a/src/data/pt/getStarted.tsx
+++ b/src/data/pt/getStarted.tsx
@@ -3,7 +3,10 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "@reach/router"
 import translateLink from "../../components/logic/translateLink"
 import CodeArea from "../../components/CodeArea"
-import { uiLibraryHookInput } from "../../components/codeExamples/getStarted"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
 import typographyStyles from "../../styles/typography.module.css"
 
 export default {
@@ -179,7 +182,12 @@ export default {
           processo para você.
         </p>
 
-        <CodeArea rawData={uiLibraryHookInput} />
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
         <p>
           <b className={typographyStyles.note}>Opção 3:</b> Por último, podemos
           setar um registro customizado usando{" "}

--- a/src/data/ru/advanced.tsx
+++ b/src/data/ru/advanced.tsx
@@ -291,7 +291,7 @@ export default {
           >
             по этой ссылке.
           </a>{" "}
-          с <PageLink to={"/api#Controller"}>Controller</PageLink>.
+          с <PageLink to="/api#Controller">Controller</PageLink>.
         </p>
       </>
     ),

--- a/src/data/ru/getStarted.tsx
+++ b/src/data/ru/getStarted.tsx
@@ -3,7 +3,10 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "gatsby"
 import translateLink from "../../components/logic/translateLink"
 import CodeArea from "../../components/CodeArea"
-import { uiLibraryHookInput } from "../../components/codeExamples/getStarted"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
 import typographyStyles from "../../styles/typography.module.css"
 
 export default {
@@ -198,7 +201,14 @@ export default {
           компонента-обёртки <Link to="/api#Controller">Controller</Link>,
           который сам позаботится о регистрации.
         </p>
-        <CodeArea rawData={uiLibraryHookInput} />
+
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
+
         <p>
           <b className={typographyStyles.note}>Вариант 3:</b> И, наконец, мы
           можем создать кастомную регистрацию с помощью{" "}

--- a/src/data/zh/advanced.tsx
+++ b/src/data/zh/advanced.tsx
@@ -274,7 +274,7 @@ export default {
             实现的链接
           </a>
           混合了
-          <PageLink to={"/api#Controller"}>Controller</PageLink>。
+          <PageLink to="/api#Controller">Controller</PageLink>。
         </p>
       </>
     ),


### PR DESCRIPTION
Added CodeSandbox's TS & JS for several more get-started codeExamples. 

Re-Added the option to ```yarn add react-hook-form``` (added a npm install duplicate when first tried this {idk how})

This also adheres to the console.log(data) for codeExamples vs console.alert I had previously been using. 

Some small linting fixes. (change ```={"something"}``` to ```="something"```)