### PR TITLE
Fix type signature for handleSubmit in docs

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -740,7 +740,7 @@ const { register } = useForm<Inputs>({
               <h2>
                 handleSubmit:{" "}
                 <span className={typographyStyles.typeText}>
-                  (data: Object, e: Event) => () => void
+                  ((data: Object, e?: Event) => void) => (e?: Event) => void
                 </span>
               </h2>
             </code>


### PR DESCRIPTION
https://react-hook-form.com/api#handleSubmit has:

`handleSubmit: (data: Object, e: Event) => () => void`

But the Typescript types in https://github.com/react-hook-form/react-hook-form/blob/master/src/types/form.ts are:

```
export type SubmitHandler<TFieldValues extends FieldValues> = (
  data: UnpackNestedValue<TFieldValues>,
  event?: React.BaseSyntheticEvent,
) => void | Promise<void>;

...

  handleSubmit: <TSubmitFieldValues extends FieldValues = TFieldValues>(
    callback: SubmitHandler<TSubmitFieldValues>,
  ) => (e?: React.BaseSyntheticEvent) => Promise<void>;

```

To simplify for the documentation, that line should be something like:

`handleSubmit: ((data: Object, e?: Event) => void) => (e?: Event) => void`

At its core handleSubmit executes a [partial application](https://en.wikipedia.org/wiki/Partial_application) in which we bind the form's validated data. At no time should handleSubmit *itself* be passed anything but a function, so let's make the documentation clear about this.