### PR TITLE
fix examples with email regex to support all TLD's

### DIFF
--- a/src/components/codeExamples/formikCode.ts
+++ b/src/components/codeExamples/formikCode.ts
@@ -6,7 +6,7 @@ function validateEmail(value) {
   
   if (!value) {
     error = "Required";
-  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i.test(value)) {
+  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$/i.test(value)) {
     error = "Invalid email address";
   }
   

--- a/src/components/codeExamples/reactHookFormCode.ts
+++ b/src/components/codeExamples/reactHookFormCode.ts
@@ -12,7 +12,7 @@ const Example = () => {
         ref={register({
           required: "Required",
           pattern: {
-            value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i,
+            value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$/i,
             message: "invalid email address"
           }
         })}

--- a/src/components/codeExamples/reduxFormCode.ts
+++ b/src/components/codeExamples/reduxFormCode.ts
@@ -12,7 +12,7 @@ const validate = values => {
     errors.username = "Nice try!";
   }
 
-  if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i.test(values.email)) {
+  if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$/i.test(values.email)) {
     errors.email = "Invalid email address";
   }
 


### PR DESCRIPTION
Currently, the examples that have email regex force the TLD (top-level domains) to be in the length range of 2-4 characters. This tripped me up for a little while when testing the sample code as we use "*@xyz.digital" for our emails and caused confusion as to if there was a bug with react-hook-form or the regex.

Hope it saves someone else some time in the future.