### PR TITLE
Feature/api doc work

### DIFF
--- a/src/components/ApiErrors.tsx
+++ b/src/components/ApiErrors.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import CodeArea from "./CodeArea"
 import errorCode from "./codeExamples/errorCode"
 import errorCodeTs from "./codeExamples/errorCodeTs"
+import errorCodeTypes from "./codeExamples/ErrorCodeTypes"
 import generic from "../data/generic"
 import multipleErrorCode from "./codeExamples/multipleErrorCode"
 import multipleErrorCodeTs from "./codeExamples/multipleErrorCodeTs"
@@ -100,6 +101,7 @@ export default React.memo(
           <CodeArea
             rawData={errorCode}
             tsRawData={errorCodeTs}
+            rawTypes={errorCodeTypes}
             url="https://codesandbox.io/s/react-hook-form-error-v6-rcpm8"
             tsUrl="https://codesandbox.io/s/react-hook-form-error-ts-v6-500eo"
           />

--- a/src/components/BuilderPage.module.css
+++ b/src/components/BuilderPage.module.css
@@ -9,7 +9,7 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.wrapper {
+.pageWrapper {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
   grid-column-gap: 60px;
@@ -19,16 +19,16 @@
   padding: 0 20px 100px 20px;
 }
 
-.wrapper > section:first-child {
+.pageWrapper > section:first-child {
   margin-top: 50px;
   order: 3;
 }
 
-.wrapper > form:nth-child(2) {
+.pageWrapper > form:nth-child(2) {
   order: 1;
 }
 
-.wrapper > section:nth-child(3) {
+.pageWrapper > section:nth-child(3) {
   order: 2;
 }
 
@@ -97,16 +97,16 @@
 }
 
 @media (min-width: 768px) {
-  .wrapper > section:first-child {
+  .pageWrapper > section:first-child {
     margin-top: 0;
     order: 1;
   }
 
-  .wrapper > form:nth-child(2) {
+  .pageWrapper > form:nth-child(2) {
     order: 2;
   }
 
-  .wrapper > section:nth-child(3) {
+  .pageWrapper > section:nth-child(3) {
     order: 3;
   }
 
@@ -115,4 +115,68 @@
     justify-content: center;
     display: flex;
   }
+}
+
+.buttonWrapper {
+  display: flex;
+  position: absolute;
+  top: 10px;
+  right: 5px;
+}
+
+.button {
+  border: none;
+  color: white;
+  border-radius: 0;
+  font-size: 13px;
+  padding: 0 10px;
+  right: 20px;
+  z-index: 1;
+  top: 10px;
+  display: none;
+  cursor: pointer;
+  text-transform: uppercase;
+  height: 34px;
+  align-items: center;
+  margin: 0 3px;
+}
+
+.button:hover {
+  background: var(--color-secondary);
+  color: white;
+}
+
+@media (min-width: 768px) {
+  .button {
+    display: flex;
+  }
+}
+
+.copyButton {
+  background: var(--color-light-blue);
+  border: 1px solid transparent;
+}
+
+.active,
+.copyButton:hover {
+  background: none;
+  border: 1px solid var(--color-secondary);
+  color: white;
+}
+
+.active,
+.copyButton:hover span {
+  background: var(--color-primary);
+}
+
+.wrapper pre {
+  line-height: 1.5 !important;
+}
+
+.wrapper pre code {
+  display: none;
+}
+
+.wrapper pre code.showCode {
+  display: block;
 }

--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -5,7 +5,8 @@ import SortableContainer from "./SortableContainer"
 import { useStateMachine } from "little-state-machine"
 import { navigate } from "@reach/router"
 import colors from "../styles/colors"
-import CodeArea from "./CodeArea"
+import generateCode from "./logic/generateCode"
+import copyClipBoard from "./utils/copyClipBoard"
 import Footer from "./Footer"
 import Popup from "./Popup"
 import LearnMore from "./learnMore"
@@ -137,7 +138,7 @@ function BuilderPage({
         {builder.builder[currentLanguage].description}
       </p>
 
-      <div className={styles.wrapper}>
+      <div className={styles.pageWrapper}>
         <section>
           <h2 className={typographyStyles.title}>
             {builder.layout[currentLanguage].title}
@@ -395,7 +396,31 @@ function BuilderPage({
             {builder.code[currentLanguage].description}
           </p>
 
-          <CodeArea data={formData} />
+          <section
+            style={{
+              position: "relative",
+            }}
+          >
+            <div className={styles.buttonWrapper}>
+              <button
+                className={`${styles.button} ${styles.copyButton}`}
+                onClick={() => {
+                  copyClipBoard(generateCode(formData))
+                  alert(generic.copied[currentLanguage])
+                }}
+                aria-label={generic.copied[currentLanguage]}
+              >
+                {generic.copy[currentLanguage]}
+              </button>
+            </div>
+            <div className={styles.wrapper}>
+              <pre className="raw-code">
+                <code className={`language-javascript ${styles.showCode}`}>
+                  {generateCode(formData)}
+                </code>
+              </pre>
+            </div>
+          </section>
         </section>
       </div>
 

--- a/src/components/CodeArea.tsx
+++ b/src/components/CodeArea.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import _ from "lodash/fp"
 import copyClipBoard from "./utils/copyClipBoard"
 import { useStateMachine } from "little-state-machine"
 import generic from "../data/generic"
@@ -37,16 +38,18 @@ export const CodeSandBoxLink = ({
 export default function CodeArea({
   rawData,
   tsRawData,
+  rawTypes,
   url,
   tsUrl,
   withOutCopy,
   isExpo,
   style,
 }: {
-  tsRawData?: string
-  tsUrl?: string
   rawData?: string
+  tsRawData?: string
+  rawTypes?: string
   url?: string
+  tsUrl?: string
   withOutCopy?: boolean
   isExpo?: boolean
   style?: any
@@ -54,7 +57,9 @@ export default function CodeArea({
   const {
     state: { language },
   } = useStateMachine()
-  const [isTS, setIsTS] = React.useState(false)
+  const [currentData, setData] = React.useState(
+    rawData || tsRawData || rawTypes
+  )
 
   const { currentLanguage } =
     language && language.currentLanguage ? language : { currentLanguage: "en" }
@@ -66,31 +71,41 @@ export default function CodeArea({
       }}
     >
       <div className={styles.buttonWrapper}>
+        {rawData && (
+          <button
+            onClick={() => setData(rawData)}
+            className={`${styles.button} ${styles.copyButton} ${
+              _.isEqual(currentData, rawData) ? styles.active : ""
+            }`}
+          >
+            JS
+          </button>
+        )}
         {tsRawData && (
-          <>
-            <button
-              onClick={() => setIsTS(false)}
-              className={`${styles.button} ${styles.copyButton} ${
-                !isTS ? styles.active : ""
-              }`}
-            >
-              JS
-            </button>
-            <button
-              onClick={() => setIsTS(true)}
-              className={`${styles.button} ${styles.copyButton} ${
-                isTS ? styles.active : ""
-              }`}
-            >
-              TS
-            </button>
-          </>
+          <button
+            onClick={() => setData(tsRawData)}
+            className={`${styles.button} ${styles.copyButton} ${
+              _.isEqual(currentData, tsRawData) ? styles.active : ""
+            }`}
+          >
+            TS
+          </button>
+        )}
+        {rawTypes && (
+          <button
+            onClick={() => setData(rawTypes)}
+            className={`${styles.button} ${styles.copyButton} ${
+              _.isEqual(currentData, rawTypes) ? styles.active : ""
+            }`}
+          >
+            Types
+          </button>
         )}
         {!withOutCopy && (
           <button
             className={`${styles.button} ${styles.copyButton}`}
             onClick={() => {
-              copyClipBoard(isTS ? tsRawData : rawData)
+              copyClipBoard(currentData)
               alert(generic.copied[currentLanguage])
             }}
             aria-label={generic.copied[currentLanguage]}
@@ -99,23 +114,36 @@ export default function CodeArea({
           </button>
         )}
 
-        {!isTS && url && <CodeSandBoxLink isExpo={isExpo} url={url} />}
-
-        {isTS && tsUrl && <CodeSandBoxLink isExpo={isExpo} url={tsUrl} />}
+        {(url || tsUrl) && (
+          <CodeSandBoxLink
+            isExpo={isExpo}
+            url={_.isEqual(currentData, rawData) ? url : tsUrl}
+          />
+        )}
       </div>
 
       <div className={styles.wrapper}>
         <pre style={style} className="raw-code">
           <code
-            className={`language-javascript ${!isTS ? styles.showCode : ""}`}
+            className={`language-javascript ${
+              _.isEqual(currentData, rawData) ? styles.showCode : ""
+            }`}
           >
             {rawData}
           </code>
-
           <code
-            className={`language-javascript ${isTS ? styles.showCode : ""}`}
+            className={`language-javascript ${
+              _.isEqual(currentData, tsRawData) ? styles.showCode : ""
+            }`}
           >
             {tsRawData}
+          </code>
+          <code
+            className={`language-javascript ${
+              _.isEqual(currentData, rawTypes) ? styles.showCode : ""
+            }`}
+          >
+            {rawTypes}
           </code>
         </pre>
       </div>

--- a/src/components/CodeArea.tsx
+++ b/src/components/CodeArea.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import copyClipBoard from "./utils/copyClipBoard"
-import generateCode from "./logic/generateCode"
 import { useStateMachine } from "little-state-machine"
 import generic from "../data/generic"
 import styles from "./CodeArea.module.css"
@@ -38,7 +37,6 @@ export const CodeSandBoxLink = ({
 export default function CodeArea({
   rawData,
   tsRawData,
-  data,
   url,
   tsUrl,
   withOutCopy,
@@ -48,7 +46,6 @@ export default function CodeArea({
   tsRawData?: string
   tsUrl?: string
   rawData?: string
-  data?: string
   url?: string
   withOutCopy?: boolean
   isExpo?: boolean
@@ -93,7 +90,7 @@ export default function CodeArea({
           <button
             className={`${styles.button} ${styles.copyButton}`}
             onClick={() => {
-              copyClipBoard((isTS ? tsRawData : rawData) || generateCode(data))
+              copyClipBoard(isTS ? tsRawData : rawData)
               alert(generic.copied[currentLanguage])
             }}
             aria-label={generic.copied[currentLanguage]}
@@ -112,7 +109,7 @@ export default function CodeArea({
           <code
             className={`language-javascript ${!isTS ? styles.showCode : ""}`}
           >
-            {rawData || generateCode(data)}
+            {rawData}
           </code>
 
           <code

--- a/src/components/VideoList.tsx
+++ b/src/components/VideoList.tsx
@@ -17,7 +17,7 @@ export default ({
   >
     <ul style={{ listStyle: "none", padding: 0, margin: "0 0 0 8px" }}>
       {lists.map(({ url, title }) => (
-        <li>
+        <li key={title}>
           <p className={styles.list}>
             <span
               style={{

--- a/src/components/codeExamples/ErrorCodeTypes.ts
+++ b/src/components/codeExamples/ErrorCodeTypes.ts
@@ -1,0 +1,83 @@
+export default `import React from "react";
+import { useForm } from "react-hook-form";
+type Inputs = {
+  a: number;
+  b: string;
+  c: Date;
+  d: {
+    e: string;
+  };
+  f: {
+    g: number[];
+    h: string[];
+    i: { j: string }[];
+  };
+  k: any;
+  l: any[];
+  m: unknown;
+  n: unknown[];
+  o: object;
+  p: object[];
+  q: {
+    r: any;
+    s: {
+      t: any[];
+      u: unknown;
+      v: object;
+    }[];
+    w: Date[];
+    x: {
+      y: {
+        z: object[];
+      };
+    };
+  };
+};
+export default function App() {
+  const { errors } = useForm<Inputs>();
+  console.log(errors?.a?.message);
+  console.log(errors?.b?.message);
+  console.log(errors?.c?.message);
+  console.log(errors?.d?.e?.message);
+  console.log(errors?.f?.g && errors.f.g[0] && errors.f.g[0].message
+  );
+  console.log(errors?.f?.h && errors.f.h[0] && errors.f.h[0].message
+  );
+  console.log(
+      errors?.f?.i &&
+      errors?.f?.i[0] &&
+      errors.f.i[0].j &&
+      errors.f.i[0].j.message
+  );
+  console.log(errors?.k?.message);
+  console.log(errors?.l?.message);
+  console.log(errors?.m?.message);
+  console.log(errors?.n && errors.n[0] && errors.n[0].message);
+  console.log(errors?.o?.message);
+  console.log(errors?.p && errors.p[0] && errors.p[0].message);
+  console.log(errors?.q?.r?.message);
+  console.log(
+    errors?.q?.s && errors.q.s[0] && errors.q.s[0].t.message
+  );
+  console.log(
+      errors?.q?.s &&
+      errors.q.s[0] &&
+      errors.q.s[0].u &&
+      errors.q.s[0].u.message
+  );
+  console.log(
+      errors?.q?.s &&
+      errors.q.s[0] &&
+      errors.q.s[0].v &&
+      errors.q.s[0].v.message
+  );
+  console.log(errors?.q?.w && errors.q.w[0] && errors.q.w[0].message
+  );
+  console.log(
+      errors?.q?.x?.y?.z &&
+      errors.q.x.y.z[0] &&
+      errors.q.x.y.z[0].message
+  );
+  return <form />;
+}
+`


### PR DESCRIPTION
- Uncouples generateCode from CodeArea
- Creates a "Types" button (per spectrum discussion)
- re-adds Types back into error options.
- add key prop to .map in VideoList (was Causing Error)

I used a-lot of _.isEqual... this can be improved but at the cost of simplicity and readability and I didn't think the "performance" was worth it... at leas until we have ~10,000 CodeAreas. But am willing to change if prompted!